### PR TITLE
Fix null safety bug in SdoPoint type conversions

### DIFF
--- a/NetSdoGeometry/OracleCustomTypeBase.cs
+++ b/NetSdoGeometry/OracleCustomTypeBase.cs
@@ -79,7 +79,7 @@ namespace NetSdoGeometry
         {
             if (OracleUdt.IsDBNull(this.connection, this.udtHandle, oracleColumnName))
             {
-                if (default(U) is ValueType)
+                if (typeof(U).IsValueType && Nullable.GetUnderlyingType(typeof(U)) == null)
                 {
                     throw new Exception(errorMessageHead + oracleColumnName.ToString() + " of value type " + typeof(U).ToString());
                 }
@@ -98,7 +98,7 @@ namespace NetSdoGeometry
         {
             if (OracleUdt.IsDBNull(this.connection, this.udtHandle, oracleColumnId))
             {
-                if (default(U) is ValueType)
+                if (typeof(U).IsValueType && Nullable.GetUnderlyingType(typeof(U)) == null)
                 {
                     throw new Exception(errorMessageHead + oracleColumnId.ToString() + " of value type " + typeof(U).ToString());
                 }

--- a/NetSdoGeometry/SdoGeometry.cs
+++ b/NetSdoGeometry/SdoGeometry.cs
@@ -4,25 +4,53 @@ namespace NetSdoGeometry
     using System.Text;
     using Oracle.DataAccess.Types;
 
+    /// <summary>
+    /// Represents an Oracle Spatial SDO_GEOMETRY object.
+    /// Maps to the MDSYS.SDO_GEOMETRY Oracle User Defined Type.
+    /// </summary>
     [Serializable]
     [OracleCustomTypeMappingAttribute("MDSYS.SDO_GEOMETRY")]
     public class SdoGeometry : OracleCustomTypeBase<SdoGeometry>
     {
+        /// <summary>
+        /// Gets or sets the geometry type information.
+        /// Format: [Dimension][LRS][GeometryType] (e.g., 2003 = 2D Polygon).
+        /// </summary>
         [OracleObjectMappingAttribute(0)]
         public decimal? SdoGtype { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Spatial Reference System Identifier.
+        /// Defines the coordinate system for the geometry.
+        /// </summary>
         [OracleObjectMappingAttribute(1)]
         public decimal? SdoSRID { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the point geometry for simple point types.
+        /// Only populated for point geometries; null for other types.
+        /// </summary>
         [OracleObjectMappingAttribute(2)]
         public SdoPoint SdoPoint { get; set; }
 
+        /// <summary>
+        /// Gets or sets the element information array.
+        /// Describes the geometry structure with triplets of (offset, element type, interpretation).
+        /// </summary>
         [OracleObjectMappingAttribute(3)]
         public decimal[] SdoElemInfo { get; set; }
 
+        /// <summary>
+        /// Gets or sets the ordinates (coordinate values) array.
+        /// Contains the actual coordinate data for the geometry.
+        /// </summary>
         [OracleObjectMappingAttribute(4)]
         public decimal[] SdoOrdinates { get; set; }
 
+        /// <summary>
+        /// Gets the geometry type as an integer value.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when SdoGtype is null.</exception>
         public int SdoGtypeAsInt
         {
             get
@@ -36,6 +64,10 @@ namespace NetSdoGeometry
             }
         }
 
+        /// <summary>
+        /// Gets or sets the Spatial Reference System Identifier as an integer.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when getting and SdoSRID is null.</exception>
         public int SdoSRIDAsInt
         {
             get
@@ -54,6 +86,10 @@ namespace NetSdoGeometry
             }
         }
 
+        /// <summary>
+        /// Gets or sets the element information array as integers.
+        /// Convenience property that converts between decimal and int arrays.
+        /// </summary>
         public int[] ElemArrayOfInts
         {
             get
@@ -79,6 +115,10 @@ namespace NetSdoGeometry
             }
         }
 
+        /// <summary>
+        /// Gets or sets the ordinates array as doubles.
+        /// Convenience property that converts between decimal and double arrays.
+        /// </summary>
         public double[] OrdinatesArrayOfDoubles
         {
             get
@@ -104,12 +144,28 @@ namespace NetSdoGeometry
             }
         }
 
+        /// <summary>
+        /// Gets or sets the dimensionality of the geometry (2D, 3D, etc.).
+        /// Extracted from the SdoGtype value.
+        /// </summary>
         public int Dimensionality { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Linear Referencing System (LRS) dimension.
+        /// Extracted from the SdoGtype value.
+        /// </summary>
         public int LRS { get; set; }
 
+        /// <summary>
+        /// Gets or sets the geometry type (Point, Line, Polygon, etc.).
+        /// Extracted from the SdoGtype value.
+        /// </summary>
         public int GeometryType { get; set; }
 
+        /// <summary>
+        /// Gets a SQL-compatible string representation of the geometry.
+        /// Returns the geometry in Oracle SDO_GEOMETRY constructor format.
+        /// </summary>
         public string AsText
         {
             get
@@ -206,6 +262,11 @@ namespace NetSdoGeometry
             this.SdoOrdinates = this.GetValue<decimal[]>((int)OracleObjectColumns.SDO_ORDINATES);
         }
 
+        /// <summary>
+        /// Extracts Dimensionality, LRS, and GeometryType from the SdoGtype value.
+        /// Populates the Dimensionality, LRS, and GeometryType properties.
+        /// </summary>
+        /// <returns>The reconstructed GTYPE value, or 0 if SdoGtype is null or 0.</returns>
         public int PropertiesFromGTYPE()
         {
             if (this.SdoGtype.HasValue && this.SdoGtype.Value != 0)
@@ -226,6 +287,11 @@ namespace NetSdoGeometry
             }
         }
 
+        /// <summary>
+        /// Constructs the SdoGtype value from Dimensionality, LRS, and GeometryType properties.
+        /// Updates the SdoGtype property with the computed value.
+        /// </summary>
+        /// <returns>The computed GTYPE value.</returns>
         public int PropertiesToGTYPE()
         {
             int v = this.Dimensionality * 1000;

--- a/NetSdoGeometry/SdoGeometry.cs
+++ b/NetSdoGeometry/SdoGeometry.cs
@@ -58,34 +58,23 @@ namespace NetSdoGeometry
         {
             get
             {
-                int[] elems = null;
-                if (this.SdoElemInfo != null)
+                if (this.SdoElemInfo == null)
                 {
-                    elems = new int[this.SdoElemInfo.Length];
-                    for (int k = 0; k < this.SdoElemInfo.Length; k++)
-                    {
-                        elems[k] = System.Convert.ToInt32(this.SdoElemInfo[k]);
-                    }
+                    return null;
                 }
 
-                return elems;
+                return System.Array.ConvertAll(this.SdoElemInfo, d => System.Convert.ToInt32(d));
             }
 
             set
             {
-                if (value != null)
+                if (value == null)
                 {
-                    int c = value.GetLength(0);
-                    this.SdoElemInfo = new decimal[c];
-            
-                    for (int k = 0; k < c; k++)
-                    {
-                        this.SdoElemInfo[k] = System.Convert.ToDecimal(value[k]);
-                    }
+                    this.SdoElemInfo = null;
                 }
                 else
                 {
-                    this.SdoElemInfo = null;
+                    this.SdoElemInfo = System.Array.ConvertAll(value, i => System.Convert.ToDecimal(i));
                 }
             }
         }
@@ -94,33 +83,23 @@ namespace NetSdoGeometry
         {
             get
             {
-                double[] elems = null;
-                if (this.SdoOrdinates != null)
+                if (this.SdoOrdinates == null)
                 {
-                    elems = new double[this.SdoOrdinates.Length];
-                    for (int k = 0; k < this.SdoOrdinates.Length; k++)
-                    {
-                        elems[k] = System.Convert.ToDouble(this.SdoOrdinates[k]);
-                    }
+                    return null;
                 }
 
-                return elems;
+                return System.Array.ConvertAll(this.SdoOrdinates, d => System.Convert.ToDouble(d));
             }
 
             set
             {
-                if (value != null)
+                if (value == null)
                 {
-                    int c = value.GetLength(0);
-                    this.SdoOrdinates = new decimal[c];
-                    for (int k = 0; k < c; k++)
-                    {
-                        this.SdoOrdinates[k] = System.Convert.ToDecimal(value[k]);
-                    }
+                    this.SdoOrdinates = null;
                 }
                 else
                 {
-                    this.SdoOrdinates = null;
+                    this.SdoOrdinates = System.Array.ConvertAll(value, d => System.Convert.ToDecimal(d));
                 }
             }
         }

--- a/NetSdoGeometry/SdoGeometry.cs
+++ b/NetSdoGeometry/SdoGeometry.cs
@@ -27,20 +27,30 @@ namespace NetSdoGeometry
         {
             get
             {
-                return System.Convert.ToInt32(this.SdoGtype);
+                if (!this.SdoGtype.HasValue)
+                {
+                    throw new InvalidOperationException("SdoGtype is null and cannot be converted to int.");
+                }
+
+                return System.Convert.ToInt32(this.SdoGtype.Value);
             }
         }
 
         public int SdoSRIDAsInt
         {
-            get 
-            { 
-                return System.Convert.ToInt32(this.SdoSRID); 
+            get
+            {
+                if (!this.SdoSRID.HasValue)
+                {
+                    throw new InvalidOperationException("SdoSRID is null and cannot be converted to int.");
+                }
+
+                return System.Convert.ToInt32(this.SdoSRID.Value);
             }
 
-            set 
-            { 
-                this.SdoSRID = System.Convert.ToDecimal(value); 
+            set
+            {
+                this.SdoSRID = System.Convert.ToDecimal(value);
             }
         }
 
@@ -219,9 +229,9 @@ namespace NetSdoGeometry
 
         public int PropertiesFromGTYPE()
         {
-            if ((int)this.SdoGtype != 0)
+            if (this.SdoGtype.HasValue && this.SdoGtype.Value != 0)
             {
-                int v = (int)this.SdoGtype;
+                int v = (int)this.SdoGtype.Value;
                 int dim = v / 1000;
                 this.Dimensionality = dim;
                 v -= dim * 1000;

--- a/NetSdoGeometry/SdoPoint.cs
+++ b/NetSdoGeometry/SdoPoint.cs
@@ -4,31 +4,58 @@ namespace NetSdoGeometry
     using Oracle.DataAccess.Client;
     using Oracle.DataAccess.Types;
 
+    /// <summary>
+    /// Represents an Oracle Spatial SDO_POINT_TYPE object.
+    /// Maps to the MDSYS.SDO_POINT_TYPE Oracle User Defined Type.
+    /// Used for simple point geometries with X, Y, and optional Z coordinates.
+    /// </summary>
     [Serializable]
     [OracleCustomTypeMappingAttribute("MDSYS.SDO_POINT_TYPE")]
     public class SdoPoint : OracleCustomTypeBase<SdoPoint>
     {
+        /// <summary>
+        /// Gets or sets the X coordinate (longitude or easting).
+        /// </summary>
         [OracleObjectMappingAttribute("X")]
         public decimal? X { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Y coordinate (latitude or northing).
+        /// </summary>
         [OracleObjectMappingAttribute("Y")]
         public decimal? Y { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Z coordinate (elevation or height).
+        /// Optional; null for 2D points.
+        /// </summary>
         [OracleObjectMappingAttribute("Z")]
         public decimal? Z { get; set; }
 
+        /// <summary>
+        /// Gets or sets the X coordinate as a double precision floating point value.
+        /// Convenience property that converts between decimal and double.
+        /// </summary>
         public double? XD
         {
             get { return this.X.HasValue ? System.Convert.ToDouble(this.X.Value) : (double?)null; }
             set { this.X = value.HasValue ? System.Convert.ToDecimal(value.Value) : (decimal?)null; }
         }
 
+        /// <summary>
+        /// Gets or sets the Y coordinate as a double precision floating point value.
+        /// Convenience property that converts between decimal and double.
+        /// </summary>
         public double? YD
         {
             get { return this.Y.HasValue ? System.Convert.ToDouble(this.Y.Value) : (double?)null; }
             set { this.Y = value.HasValue ? System.Convert.ToDecimal(value.Value) : (decimal?)null; }
         }
 
+        /// <summary>
+        /// Gets or sets the Z coordinate as a double precision floating point value.
+        /// Convenience property that converts between decimal and double.
+        /// </summary>
         public double? ZD
         {
             get { return this.Z.HasValue ? System.Convert.ToDouble(this.Z.Value) : (double?)null; }

--- a/NetSdoGeometry/SdoPoint.cs
+++ b/NetSdoGeometry/SdoPoint.cs
@@ -19,20 +19,20 @@ namespace NetSdoGeometry
 
         public double? XD
         {
-            get { return System.Convert.ToDouble(this.X); }
-            set { this.X = System.Convert.ToDecimal(value); }
+            get { return this.X.HasValue ? System.Convert.ToDouble(this.X.Value) : (double?)null; }
+            set { this.X = value.HasValue ? System.Convert.ToDecimal(value.Value) : (decimal?)null; }
         }
 
         public double? YD
         {
-            get { return System.Convert.ToDouble(this.Y); }
-            set { this.Y = System.Convert.ToDecimal(value); }
+            get { return this.Y.HasValue ? System.Convert.ToDouble(this.Y.Value) : (double?)null; }
+            set { this.Y = value.HasValue ? System.Convert.ToDecimal(value.Value) : (decimal?)null; }
         }
 
         public double? ZD
         {
-            get { return System.Convert.ToDouble(this.Z); }
-            set { this.Z = System.Convert.ToDecimal(value); }
+            get { return this.Z.HasValue ? System.Convert.ToDouble(this.Z.Value) : (double?)null; }
+            set { this.Z = value.HasValue ? System.Convert.ToDecimal(value.Value) : (decimal?)null; }
         }
 
         public override void MapFromCustomObject()


### PR DESCRIPTION
The XD, YD, and ZD properties were calling Convert.ToDouble/ToDecimal
on nullable values without checking for null first. This would throw
an InvalidCastException when the underlying decimal properties are null.

Now properly checks HasValue before conversion and returns null when
the source value is null.